### PR TITLE
Avoid AttributeError when calling show_hids.py

### DIFF
--- a/pywinusb/hid/core.py
+++ b/pywinusb/hid/core.py
@@ -14,6 +14,7 @@ import threading
 import collections
 if sys.version_info >= (3,):
     import winreg
+    collections.Callable = collections.abc.Callable
 else:
     import _winreg as winreg
 


### PR DESCRIPTION
Taken over from pending pull request of rene-aguirre/pywinusb